### PR TITLE
Pasting hyperlink format

### DIFF
--- a/src/textbrowser.cpp
+++ b/src/textbrowser.cpp
@@ -26,6 +26,8 @@
 #include "textbrowser.h"
 #include <QTextBrowser>
 #include <QDesktopServices>
+#include <QMimeData>
+#include <QTextDocumentFragment>
 
 TextBrowser::TextBrowser(QWidget *parent) : QTextBrowser(parent)
 {
@@ -48,6 +50,30 @@ void TextBrowser::focusOutEvent(QFocusEvent *e)
 void TextBrowser::openLinkInBrowser(const QUrl link)
 {
     QDesktopServices::openUrl(link);
+}
+
+void TextBrowser::insertFromMimeData(const QMimeData *source)
+{
+    QTextCharFormat format = this->textCursor().charFormat();
+
+    if (source->hasHtml()) {
+            QTextDocumentFragment fragment = QTextDocumentFragment::fromHtml(source->html(), this->document());
+            this->textCursor().insertFragment(fragment);
+           ensureCursorVisible();
+
+           textCursor().insertText(" ",format);
+           textCursor().movePosition(QTextCursor::Right);
+
+    }
+    else {
+        QTextBrowser::insertFromMimeData(source);
+    }
+}
+
+bool TextBrowser::canInsertFromMimeData(const QMimeData *source) const
+{
+    QTextCharFormat format = this->textCursor().charFormat();
+
 }
 
 void TextBrowser::slotSetReadOnly(bool ro)

--- a/src/textbrowser.cpp
+++ b/src/textbrowser.cpp
@@ -62,8 +62,6 @@ void TextBrowser::insertFromMimeData(const QMimeData *source)
            ensureCursorVisible();
 
            textCursor().insertText(" ",format);
-           textCursor().movePosition(QTextCursor::Right);
-
     }
     else {
         QTextBrowser::insertFromMimeData(source);

--- a/src/textbrowser.h
+++ b/src/textbrowser.h
@@ -52,6 +52,8 @@ public slots:
 
 private slots:
       void openLinkInBrowser(const QUrl link);
+      void insertFromMimeData(const QMimeData *source);
+      bool canInsertFromMimeData(const QMimeData *source) const;
 };
 
 #endif // TEXTEDIT_H

--- a/src/textformattingtoolbar.cpp
+++ b/src/textformattingtoolbar.cpp
@@ -316,10 +316,15 @@ QRegExp(">\\b([a-zA-Z0-9_\\.\\-]+@[a-zA-Z0-9_\\.\\-]+)\\b(<?)", Qt::CaseInsensit
     if(selectedText.isEmpty())
         selectedText = link;
 
+    QTextCharFormat format = cursor.charFormat();
+
+
     if(link.contains("@"))
       cursor.insertHtml("<a href=mailto:"+link+"\">"+selectedText+"</a>");
     else
       cursor.insertHtml("<a href=\""+link+"\">"+selectedText+"</a>");
+
+    cursor.insertText(" ",format);
 }
 
 void TextFormattingToolbar::fontOfText(const QString &f){


### PR DESCRIPTION
This fixes the issue that text typed after pasting a hyperlink also becomes part of the hyperlink. 