### PR TITLE
Fix font size and default font on Windows 10

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,9 +33,18 @@
 #include "welcome.h"
 
 int main (int argc, char *argv[]){
+
      QApplication app(argc, argv);
+
+#ifdef Q_OS_WINDOWS
+     // this replaces Qt's MS ShellDlg2 font with the proper Windows font in some labels
+     app.setFont(QApplication::font("QMenu"));
+#endif
+
+
      app.setApplicationName("nobleNote");
      app.setOrganizationName("nobleNote");
+
 
      //Qt translations
      QTranslator qtTranslator;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -698,7 +698,7 @@ void MainWindow::openNoteSource()
     mainWindow->setCentralWidget(textEdit);
     TextSearchToolbar * searchBar = new TextSearchToolbar(textEdit,mainWindow);
     mainWindow->addToolBar(searchBar);
-    mainWindow->resize(QSettings().value("note_editor_default_size",QSize(335,250)).toSize());
+    mainWindow->resize(Note::editorSize());
 //    searchBar->searchLine()->setFocus();
 //    searchBar->setFocusPolicy(Qt::TabFocus);
 

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -105,8 +105,7 @@ void Note::highlightText(const QString &str)
 
 void Note::loadSizeAndShow()
 {
-    QSize defaultSize(QSettings().value("note_editor_default_size",QSize(335,250)).toSize());
-    QSize size = QSettings().value("Notes/"+noteDescriptor_->uuid().toString()+"_size", defaultSize).toSize();
+    QSize size = QSettings().value("Notes/"+noteDescriptor_->uuid().toString()+"_size", editorSize()).toSize();
     resize(size);
     if(showAfterLoading_)
     {
@@ -221,4 +220,9 @@ void Note::showOrHideToolbars()
 void Note::showAfterLoaded()
 {
     showAfterLoading_ = true;
+}
+
+/*static*/ QSize Note::editorSize()
+{
+    return QSettings().value("note_editor_default_size",QSize(650,400)).toSize();
 }

--- a/src/note.h
+++ b/src/note.h
@@ -78,6 +78,8 @@ class Note : public QMainWindow, public Ui::Note {
 
       // adds this file Path to the list of open notes that is stored in the settings
       static void addToOpenNoteList(QString path);
+
+      static QSize editorSize();
 private:
       TextBrowser *textBrowser;
       TextDocument *textDocument;

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -23,6 +23,7 @@
  * nobleNote is licensed under the MIT, see `http://copyfree.org/licenses/mit/license.txt'.
  */
 
+#include "note.h"
 #include "preferences.h"
 #include <QDir>
 #include <QMessageBox>
@@ -45,8 +46,8 @@ Preferences::Preferences(QWidget *parent): QDialog(parent)
      showSource->setChecked(settings->value("show_source", false).toBool());
      kineticScrolling->setChecked(settings->value("kinetic_scrolling", false).toBool());
      silentStart->setChecked(settings->value("Hide_main_at_startup",false).toBool());
-     sizeSpinHeight->setValue(settings->value("note_editor_default_size",QSize(335,250)).toSize().height());
-     sizeSpinWidth->setValue(settings->value("note_editor_default_size",QSize(335,250)).toSize().width());
+     sizeSpinHeight->setValue(Note::editorSize().height());
+     sizeSpinWidth->setValue(Note::editorSize().width());
 
 
      connect(buttonBox, SIGNAL(accepted()), this, SLOT(saveSettings()));

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>280</width>
-    <height>331</height>
+    <width>600</width>
+    <height>400</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -29,8 +29,8 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>280</width>
-     <height>23</height>
+     <width>600</width>
+     <height>26</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">


### PR DESCRIPTION
Use the default windows 10 font in all dialogs. Increased the default size for the main window and the note editor windows. 