### PR TITLE
Correctly restore window state

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -68,7 +68,7 @@ MainWindow::MainWindow()
      QIcon icon = QIcon(":nobleNote");
 
      minimizeRestoreAction = new QAction(tr("&Restore"),this);
-     quit_action = new QAction(tr("&Quit"),this);
+     actionQuitSystrayMenu = new QAction(tr("&Quit"),this);
 
 #ifndef NO_SYSTEM_TRAY_ICON
      TIcon = new QSystemTrayIcon(this);
@@ -78,7 +78,7 @@ MainWindow::MainWindow()
    //TrayIconContextMenu
      iMenu = new QMenu(this);
      iMenu->addAction(minimizeRestoreAction);
-     iMenu->addAction(quit_action);
+     iMenu->addAction(actionQuitSystrayMenu);
 
      TIcon->setContextMenu(iMenu);  //setting contextmenu for the systray
 #endif
@@ -208,10 +208,10 @@ MainWindow::MainWindow()
 #endif
 
      connect(actionImport,SIGNAL(triggered()),noteImporter,SLOT(importDialog()));
-     connect(actionQuit, SIGNAL(triggered()), this, SLOT(quit()));
+     connect(actionQuitFileMenu, SIGNAL(triggered()), this, SLOT(quit()));
 
      connect(actionTrash, SIGNAL(triggered()), this, SLOT(showBackupWindow()));
-     connect(quit_action, SIGNAL(triggered()), this, SLOT(quit())); //contextmenu "Quit" for the systray
+     connect(actionQuitSystrayMenu, SIGNAL(triggered()), this, SLOT(quit()));
      connect(actionNew_folder, SIGNAL(triggered()), this, SLOT(newFolder()));
      connect(actionRename_folder, SIGNAL(triggered()), this, SLOT(renameFolder()));
      connect(actionDelete_folder, SIGNAL(triggered()), this, SLOT(removeFolder()));
@@ -537,7 +537,6 @@ void MainWindow::closeEvent(QCloseEvent* window_close)
        QSettings().setValue("mainwindow_size", saveGeometry());
        QSettings().setValue("splitter", splitter->saveState());
 
-       // find widgets that still are saving their settings and let their futuures (worker threads) finish
        QListIterator<QPointer<QWidget> > it(openNotes);
        while(it.hasNext())
        {
@@ -546,8 +545,6 @@ void MainWindow::closeEvent(QCloseEvent* window_close)
            Note * note = qobject_cast<Note*>(widget);
            if(note != NULL)
            {
-               // calls close event (this is normally not called, because Notes are no childs of this)
-               // TODO check why Notes are no children of this
 
                note->close();
 
@@ -566,7 +563,9 @@ void MainWindow::quit()
 {
      QSettings().setValue("mainwindow_size", saveGeometry());
      QSettings().setValue("mainwindow_toolbar_visible", actionShowToolbar->isChecked());
-     qApp->quit();
+     qApp->setQuitOnLastWindowClosed(true);
+     qApp->closeAllWindows();
+     close();
 }
 
 bool MainWindow::noteIsOpen(const QString &path)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -550,8 +550,6 @@ void MainWindow::closeEvent(QCloseEvent* window_close)
                // TODO check why Notes are no children of this
 
                note->close();
-               if(!note->future().isFinished())
-                   note->future().waitForFinished();
 
                // close() calls the closeEvent, this method assumes the user has closed the window
                // so we manually have to re-add this note to the list of open notes.

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -107,7 +107,7 @@ private:
       FileSystemModel *noteFSModel;
       FindFileSystemModel *noteModel;
       QListView        *folderView, *noteView;
-      QAction         *quit_action, *minimizeRestoreAction;
+      QAction         *actionQuitSystrayMenu, *minimizeRestoreAction;
       QPointer<Preferences> pref;
       QHBoxLayout     *hBoxLayout;
       FindFileModel   *findNoteModel;

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -84,12 +84,6 @@ Note::Note(QString filePath, QWidget *parent) : QMainWindow(parent){
      searchBar->setFocusPolicy(Qt::TabFocus);
      addToolBar(searchBar);
 
-     restoreState(QSettings().value("Note_window_and_toolbar/state").toByteArray());
-
-     if(QSettings().value("Notes/"+noteDescriptor_->uuid().toString()+"_window_position").isValid())
-        restoreGeometry(QSettings().value("Notes/"+noteDescriptor_->uuid().toString()+"_window_position").toByteArray());
-     else // center in desktop if there's no saved position
-        move(QApplication::desktop()->screen()->rect().center() - rect().center());
 
 
      connect(noteDescriptor_,SIGNAL(close()),this,SLOT(close()));
@@ -111,6 +105,8 @@ void Note::loadSizeAndShow()
     {
         show();
     }
+    restoreWindowState();
+
 }
 
 void Note::closeEvent(QCloseEvent* close_Note)
@@ -122,8 +118,7 @@ void Note::closeEvent(QCloseEvent* close_Note)
     variantList << size() << saveState() << saveGeometry() << textBrowser->textCursor().position() <<
                            noteDescriptor()->uuid().toString() << noteDescriptor()->filePath();
 
-   // run it asynchronously to avoid blocking the gui thread, when he destroys the window
-     future_ = QtConcurrent::run(this, &Note::saveWindowState,variantList);
+    saveWindowState(variantList);
      QMainWindow::closeEvent(close_Note);
 }
 
@@ -149,6 +144,17 @@ void Note::saveWindowState(QVariantList variantList)
     QSettings().setValue("open_notes", savedOpenNoteList);
 
 
+
+}
+
+void Note::restoreWindowState()
+{
+    restoreState(QSettings().value("Note_window_and_toolbar/state").toByteArray());
+
+    if(QSettings().value("Notes/"+noteDescriptor_->uuid().toString()+"_window_position").isValid())
+       restoreGeometry(QSettings().value("Notes/"+noteDescriptor_->uuid().toString()+"_window_position").toByteArray());
+    else // center in desktop if there's no saved position
+       move(QApplication::desktop()->screen()->rect().center() - rect().center());
 
 }
 

--- a/src/note.h
+++ b/src/note.h
@@ -73,9 +73,6 @@ class Note : public QMainWindow, public Ui::Note {
 
       QTextEdit * textEdit() const { return textBrowser;}
 
-      // the future of the worker thread that handles saving settings
-      QFuture<void> future() const { return future_;}
-
       // adds this file Path to the list of open notes that is stored in the settings
       static void addToOpenNoteList(QString path);
 
@@ -88,13 +85,13 @@ private:
 
       TextFormattingToolbar *toolbar;
       TextSearchToolbar *searchBar;
-      QFuture<void> future_; // a future that holds the worker thread that is invoked when window states are changed
 
       NoteDescriptor *noteDescriptor_;
       bool showAfterLoading_; // state variable, call show() after loadSizeAndShow()
 
       // this is called asynchronously when the window is closed and saves geometry etc.
       void saveWindowState(QVariantList variantList);
+      void restoreWindowState();
 public slots:
       void setSearchBarText(QString str);
 

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -46,7 +46,7 @@
     <addaction name="separator"/>
     <addaction name="actionImport"/>
     <addaction name="actionTrash"/>
-    <addaction name="actionQuit"/>
+    <addaction name="actionQuitFileMenu"/>
    </widget>
    <widget class="QMenu" name="menu_Settings">
     <property name="title">
@@ -96,7 +96,7 @@
     <bool>false</bool>
    </attribute>
   </widget>
-  <action name="actionQuit">
+  <action name="actionQuitFileMenu">
    <property name="text">
     <string>&amp;Quit</string>
    </property>


### PR DESCRIPTION
Restore the window state including its geometry and position for note windows after the windows have been reopened. 