### PR TITLE
218 search result windows

### DIFF
--- a/src/findfilemodel.cpp
+++ b/src/findfilemodel.cpp
@@ -126,16 +126,20 @@ QMimeData *FindFileModel::mimeData(const QModelIndexList &indexes) const
 }
 
  // this method may be called multiple times if the user is typing a search word
-void FindFileModel::findInFiles(const QString& fileName, const QString &content,const QString &path)
+void FindFileModel::findInFiles(const QString& fileName, const QString &content,const QString &path, bool waitCursor)
 {
 
     if(path.isEmpty() || (fileName.isEmpty() && content.isEmpty()))
         return;
 
     if(future.isRunning())
+    {
         future.cancel();
-    else
+    }
+    else if(waitCursor)
+    {
         QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
+    }
 
     QStringList files;
     QDirIterator it(path, QDirIterator::Subdirectories);
@@ -152,7 +156,6 @@ void FindFileModel::findInFiles(const QString& fileName, const QString &content,
     future = QtConcurrent::filtered(files,fileContainsFunctor);
 
     futureWatcher.setFuture(future);
-
     // sometimes, wait cursor persists, this is a workaround
     QTimer::singleShot(5000,this,SLOT(restoreOverrideCursor()));
 }

--- a/src/findfilemodel.cpp
+++ b/src/findfilemodel.cpp
@@ -101,7 +101,7 @@ bool FindFileModel::setData(const QModelIndex &index, const QVariant &value, int
      QStandardItemModel::setData(index,value,role); //set new name for list item
      //rename file before changing path of original file
      //value can be folder/filename or simply filename
-     bool f = QFile::rename(filePath(index),fileInfo(index).path() + QDir::separator() + QFileInfo(value.toString()).fileName());
+     bool f = QFile::rename(filePath(index),fileInfo(index).path() + QDir::separator() + QFileInfo(value.toString()).fileName().trimmed());
 
      //change path data
      QStandardItemModel::setData(index, fileInfo(index).path() + QDir::separator() + QFileInfo(value.toString()).fileName(), Qt::UserRole + 1);

--- a/src/findfilemodel.cpp
+++ b/src/findfilemodel.cpp
@@ -87,10 +87,8 @@ void FindFileModel::appendFile(QString filePath)
         return;
     }
 
-    QString filePathTrunc = info.filePath();
+    QString filePathTrunc = info.dir().dirName() + " / " + info.fileName();
 
-    while(filePathTrunc.count(QDir::separator()) > 1)
-      filePathTrunc.remove(0,filePathTrunc.indexOf(QDir::separator())+1);
 
     QStandardItem * fileItem = new QStandardItem(filePathTrunc);
     fileItem->setIcon(QFileIconProvider().icon(info));

--- a/src/findfilemodel.h
+++ b/src/findfilemodel.h
@@ -51,7 +51,7 @@ public:
     QFileInfo fileInfo(const QModelIndex & index) const;
     void appendFile(QString filePath); // append file with full path
     static QStringList find0(const QString &searchName, const QString &searchText,const QString& path); // searchName and searchText can be null QStrings
-    void findInFiles(const QString &path, const QString& fileName, const QString &content);
+    void findInFiles(const QString &path, const QString& fileName, const QString &content, bool waitCursor);
 
     QStringList mimeTypes() const;
     QMimeData * mimeData(const QModelIndexList &indexes) const;

--- a/src/findfilesystemmodel.cpp
+++ b/src/findfilesystemmodel.cpp
@@ -195,11 +195,11 @@ void FindFileSystemModel::clear()
         qDebug("FindFileSystemModel::clear failed: cast failed");
 }
 
-void FindFileSystemModel::findInFiles(const QString &fileName, const QString &content, const QString &path)
+void FindFileSystemModel::findInFiles(const QString &fileName, const QString &content, const QString &path, bool waitCursor)
 {
     if(FindFileModel* ffm= qobject_cast<FindFileModel*>(sourceModel()))
     {
-        ffm->findInFiles(fileName,content,path);
+        ffm->findInFiles(fileName,content,path, waitCursor);
         return;
     }
     qDebug("FindFileSystemModel::findInFiles failed: cast failed");

--- a/src/findfilesystemmodel.h
+++ b/src/findfilesystemmodel.h
@@ -55,7 +55,7 @@ public:
     QModelIndex setRootPath(const QString & newPath);
     QString rootPath() const;
     void clear();
-    void findInFiles(const QString& fileName, const QString &content, const QString &path);
+    void findInFiles(const QString& fileName, const QString &content, const QString &path, bool waitCursor);
     QModelIndex index ( const QString & path, int column = 0 ) const; // wrapper method for the corresponding QFileSystemModel method
     void copyNotesToBackupDir(const QModelIndexList &indexes) const; // reads the uuid from each note and copys the note to the backup dir with the uuid as its name
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -247,6 +247,14 @@ MainWindow::MainWindow()
 
      connect(folderFSModel, SIGNAL(droppedAFile()), this, SLOT(createAndUpdateRecent())); //moving a note with
                                                                  //drag and drop removes it from the recent files
+
+     connect(folderFSModel,&FileSystemModel::droppedAFile, this, [this](){
+         QString text = searchText->text();
+         if(!text.isEmpty())
+         {
+             find(false);
+         }
+     });
 }
 
 MainWindow::~MainWindow()
@@ -398,7 +406,7 @@ void MainWindow::showBackupWindow()
        backup = new Backup(this);
 }
 
-void MainWindow::find()
+void MainWindow::find(bool waitCursorEnabled)
 {
     // disable note toolbar buttons because the current notes are not longer visible with the findNoteModel
 
@@ -407,7 +415,7 @@ void MainWindow::find()
          noteModel->setSourceModel(findNoteModel);
          noteModel->clear(); // if findNoteModel already set, clear old found list
          //noteModel->findInFiles(searchName->text(),searchText->text(),folderModel->rootPath());
-         noteModel->findInFiles(searchText->text(),searchText->text(),folderModel->rootPath());
+         noteModel->findInFiles(searchText->text(),searchText->text(),folderModel->rootPath(),waitCursorEnabled);
 
          actionNew_note->setDisabled(true);
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -146,7 +146,7 @@ private:
       void tray_actions();
 #endif
 
-      void find();
+      void find(bool waitCursorEnabled = true);
       void openNote(const QModelIndex &ind);
       void openOneNote(QString path);
       void openAllNotes();

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -106,6 +106,16 @@ void Note::loadSizeAndShow()
         show();
     }
     restoreWindowState();
+    if(!searchBar->text().isEmpty())
+    {
+        searchBar->searchLine()->setFocus();
+        searchBar->selectNextExpression();
+        searchBar->show();
+    }
+    else
+    {
+        searchBar->hide();
+    }
 
 }
 
@@ -170,8 +180,11 @@ void Note::keyPressEvent(QKeyEvent *k){
          searchBar->setText(textBrowser->textCursor().selectedText());
        }
        if(!searchBar->isVisible())
+       {
          searchBar->setVisible(true);
          searchBar->searchLine()->setFocus();
+        }
+
      }
 
      if((k->modifiers() == Qt::ControlModifier) && (k->key() == Qt::Key_T))

--- a/src/textsearchtoolbar.cpp
+++ b/src/textsearchtoolbar.cpp
@@ -42,7 +42,7 @@ TextSearchToolbar::TextSearchToolbar(QTextEdit * textEdit, QWidget *parent) :
      connect(typingTimer,&QTimer::timeout,this,&TextSearchToolbar::selectNextExpression);
 
      closeSearch = new QToolButton(this);
-     closeSearch->setText("X");
+     closeSearch->setText("❌");
      closeSearch->setShortcut(Qt::Key_Escape);
      addWidget(closeSearch);
 

--- a/src/textsearchtoolbar.h
+++ b/src/textsearchtoolbar.h
@@ -44,6 +44,8 @@ public:
 
      QLineEdit* searchLine() { return searchLine_;}
 
+     QString text() const { return searchLine_->text(); }
+
 public slots:
      void selectPreviousExpression();
      void highlightText(QString str);


### PR DESCRIPTION
fixes #218 

Scroll to the first occurence of the search word when using the "find text in notes" search bar. 

Do not open the search toolbar inside the note editor automatically when the editor is not opened via the "find text in notes" search bar. 