### PR TITLE
Fixes crashes and "ghost windows" when using the recycle bin (trash)

### DIFF
--- a/src/backup.cpp
+++ b/src/backup.cpp
@@ -99,7 +99,6 @@ void Backup::setupBackups()
      progressDialog2 = new QProgressDialog(parent_);
      progressDialog2->setLabelText(QString(tr("Indexing trash...")));
      setupBackup.p = progressReceiver2;
-     setupBackup.p = progressReceiver2;
 
      auto future = QtConcurrent::mapped(backupFiles, setupBackup);
      future2 = new QFutureWatcher<QPair<QString, QStringList>>(this);

--- a/src/progressreceiver.cpp
+++ b/src/progressreceiver.cpp
@@ -33,7 +33,6 @@ ProgressReceiver::ProgressReceiver(QObject *parent) :
 {
     interval_ = 20;
     value_ = 0;
-    time_  = QTime::currentTime();
 }
 
 // if the event user type collides with an existing user type, the static_cast in the
@@ -47,14 +46,10 @@ void ProgressReceiver::postProgressEvent()
     ProgressEvent * me = new ProgressEvent(static_cast<QEvent::Type>(QEvent::User + userTypeOffset));
     me->value = value_;
 
-    // only report periodically
-    if(QTime::currentTime() > time_)
-    {
-        time_ = time_.addMSecs(interval_);
 
         // ProgressReceiver now receives a event with the current progress
-        QCoreApplication::postEvent(this,me);
-    }
+    QCoreApplication::postEvent(this,me);
+
 }
 
 bool ProgressReceiver::event(QEvent *e)

--- a/src/progressreceiver.h
+++ b/src/progressreceiver.h
@@ -78,9 +78,7 @@ private:
     };
 
     int interval_;
-    int value_;
-    QTime time_;
-    
+    int value_;    
 };
 
 #endif // PROGRESSRECEIVER_H


### PR DESCRIPTION
See title. Opening the trash dialog sometimes causes a segfault or the progressbar hangs. Sometimes an empty "ghost window" is left behind after using the nobleNote trash dialog. 