### PR TITLE
Fix generation of .qm translation files, properly run lrelease on systems where only Qt6 is installed

### DIFF
--- a/nobleNote.pro
+++ b/nobleNote.pro
@@ -20,7 +20,7 @@ win32 {
 RC_FILE += icon.rc
 }
 
-system(lrelease nobleNote.pro)
+system($$[QT_HOST_BINS]/lrelease nobleNote.pro)
 
 QMAKE_DISTCLEAN = src/translations/*.qm
 


### PR DESCRIPTION
Sets the path to lrelease via Qt's own environment variable so that .qm translation files are properly generated for Qt6 builds. Debian package builds now also no longer fail because of missing .qm files. 
fixes #238 