### PR TITLE
fix not quitting app on explicit quit. Closes #220

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -604,7 +604,7 @@ void MainWindow::quit()
      QSettings().setValue("mainwindow_toolbar_visible", actionShowToolbar->isChecked());
      qApp->setQuitOnLastWindowClosed(true);
      qApp->closeAllWindows();
-     close();
+     qApp->quit();
 }
 
 bool MainWindow::noteIsOpen(const QString &path)


### PR DESCRIPTION
This PR fixes NobleNote not quitting on an explicit quit request from the tray icon or the main window menu.  
Closing to tray will now function correctly when closing the main window.